### PR TITLE
Make it build again

### DIFF
--- a/src/graphic/gra_lib.cpp
+++ b/src/graphic/gra_lib.cpp
@@ -256,10 +256,10 @@ void GraLib::recolor_into_vector(
 
 
 void GraLib::add_replace(const std::string& a, const std::string& b) {
-    replace_exact .insert(std::make_pair <std::string, std::string> (a, b));
+    replace_exact .insert(std::make_pair (a, b));
 }
 void GraLib::add_substr_replace(const std::string& a, const std::string& b) {
-    replace_substr.insert(std::make_pair <std::string, std::string> (a, b));
+    replace_substr.insert(std::make_pair (a, b));
 }
 
 


### PR DESCRIPTION
On arch the build fails at the moment - possibly to newer libraries.

```
src/graphic/gra_lib.cpp: In member function 'void GraLib::add_replace(const string&, const string&)':
src/graphic/gra_lib.cpp:259:74: error: no matching function for call to 'make_pair(const string&, const string&)'
     replace_exact .insert(std::make_pair <std::string, std::string> (a, b));
[…]
```

As pointed out from x79 [1], [2] this patch fixes the failing build.

[1]: https://aur.archlinux.org/packages/lix-git/?comments=all
[2]: https://aur.archlinux.org/packages/lix/?comments=all